### PR TITLE
Remove internal development warning from README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ If you would like to see a bug fixed or a new feature implemented,
 please open an issue for the discussion rather than directly opening
 a pull request.
 
-If you would like to contribute please read [CONTRIBUTING.md](/CONTRIBUTING.md).
+If you would like to contribute please read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
 
 When you finally create a pull request, please follow these guidelines:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> :warning: The Cartesi team keeps working internally on the next version of this repository, following its regular development roadmap. Whenever there's a new version ready or important fix, these are published to the public source tree as new releases.
-
 # Cartesi Machine Emulator ROM
 
 The Cartesi Machine Emulator ROM is the reference software that boots a guest Operating System on the emulator.
@@ -16,11 +14,11 @@ The Cartesi Machine Emulator ROM is the reference software that boots a guest Op
 ### Build
 
 ```bash
-$ make downloads 
+$ make downloads
 $ make toolchain-env
 [toolchain-env]$ make dep
 [toolchain-env]$ make
-[toolchain-env]$ exit 
+[toolchain-env]$ exit
 ```
 
 Cleaning:


### PR DESCRIPTION
Remove old waning about internal development. Also remove trailing white space.
